### PR TITLE
Recognise pretrans and posttrans as valid keywords

### DIFF
--- a/RPM Spec.JSON-tmLanguage
+++ b/RPM Spec.JSON-tmLanguage
@@ -54,7 +54,7 @@
 			"match": "%([A-Z_a-z_0-9_]+)",
 			"name": "variable.spec"
 		}, {
-			"match": "^%(build$|changelog|check$|clean$|description|files|install$|package|prep$|pre|preun|post|postun|trigger|triggerin|triggerpostun|triggerun|verifyscript)",
+			"match": "^%(build$|changelog|check$|clean$|description|files|install$|package|prep$|pre|preun|pretrans|post|postun|posttrans|trigger|triggerin|triggerpostun|triggerun|verifyscript)",
 			"name": "keyword.control.spec"
 		}, {
 			"match": "%(if|else|endif|define|global|undefine)",

--- a/RPM Spec.tmLanguage
+++ b/RPM Spec.tmLanguage
@@ -122,7 +122,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>^(%(prep$|build$|install$|clean$|(pre|post)(un)?|trigger(in|un|postun)|verifyscript))</string>
+			<string>^(%(prep$|build$|install$|clean$|(pre|post)(un|trans)?|trigger(in|un|postun)|verifyscript))</string>
 			<key>name</key>
 			<string>keyword.control.spec</string>
 		</dict>


### PR DESCRIPTION
Small patch to recognise the %pretrans and %posttrans keywords.